### PR TITLE
Add simple demo page, "no image" response

### DIFF
--- a/GifBot.php
+++ b/GifBot.php
@@ -7,8 +7,12 @@ define('GIPHY_API_KEY', 'dc6zaTOxFJmzC');
 
 // Get request
 $trigger = $_POST['trigger_word'];
-$search  = trim(substr($_POST['text'], strlen($trigger) + 1));
+$text = $_POST['text'];
 
+// build search string
+$search  = trim(substr($text, strlen($trigger) + 1));
+
+// fail if search string is empty
 if ($search == '') {
     echo 'OK';
     exit;
@@ -16,16 +20,24 @@ if ($search == '') {
 
 // Query Giphy - http://giphy.com/
 $limit    = 25;
-$response = file_get_contents('http://api.giphy.com/v1/gifs/search?q=' . urlencode($search) . '&api_key=' . GIPHY_API_KEY . '&limit=' . $limit . '&offset=0');
+$response = file_get_contents('http://api.giphy.com/v1/gifs/search?q=' .
+            urlencode($search) . '&api_key=' . GIPHY_API_KEY . '&limit=' . $limit . '&offset=0');
 $response = json_decode($response);
 
 // Pick a random GIF
 $gifs  = $response->data;
 $count = count($gifs);
-$image = $gifs[rand(0, $count - 1)]->images->original;
 
-// Respond with GIF
+// make sure we have an image
+if ($count) {
+    $image = $gifs[rand(0, $count - 1)]->images->original;
+    $response = $image->url;
+} else {
+    $response = 'No image found for `' . $search . '`';
+}
+
+// Respond
 header('Content-Type: application/json');
 echo json_encode(array(
-    'text' => $image->url
+    'text' => $response
 ));

--- a/GifBot_test.html
+++ b/GifBot_test.html
@@ -1,0 +1,65 @@
+<html>
+<head>
+    <title>GifBot test page</title>
+    <style>
+        * { font-family: "Trebuchet MS", verdana, arial, sans-serif; }
+        input { font-size: 1.2em; }
+        #results {
+            border: 2px dashed #bbbbbb;
+            color: #bbbbbb;
+            min-height: 100px;
+            padding: 10px;
+        }
+    </style>
+</head>
+<body>
+
+    <h1>GifBot test</h1>
+
+    <p>
+        A simple test page for the Bold GifBot Slack plugin:<br />
+        <a href="https://github.com/bold/GifBot">https://github.com/bold/GifBot</a>
+    </p>
+    <p>
+        Upload this page to the same directory as GifBot.php. Test until it works.<br />
+        You might want to delete this page when you're done.
+    </p>
+
+    <form action="GifBot.php" method="POST">
+        <input type="hidden" name="trigger_word" value="gif" />
+        Search phrase: <input type="text" name="text" placeholder="gif <search term>" />
+        <input type="submit" />
+    </form>
+
+    <div id="results">
+        Results
+    </div>
+
+    <script src="https://code.jquery.com/jquery-2.1.1.min.js"></script>
+    <script>
+        $(function(){
+            $('form').submit(function(e){
+                e.preventDefault();
+
+                var $form = $(this),
+                    text = $form.find('[name="text"]').val(),
+                    trigger_word = $form.find('[name="trigger_word"]').val(),
+                    url = $(this).attr('action');
+
+                $.post(url, { text: text, trigger_word: trigger_word })
+                    .success(function(data){
+                        var $resultContainer = $('#results'),
+                            result;
+                        if (data.text.indexOf('http') >= 0) {
+                            result = '<img src="' + data.text + '" />';
+                        } else {
+                            result = data.text;
+                        }
+                        $resultContainer.html(result);
+                    });
+            });
+        });
+    </script>
+
+</body>
+</html>


### PR DESCRIPTION
This PR adds a simple demo page which allows users to test GifBot on their server before adding it to Slack. It also adds a "no image" response for times when the given search string returns nothing from Giphy.
