### PR TITLE
#gifbomb <num> <search_term>

### DIFF
--- a/GifBot.php
+++ b/GifBot.php
@@ -5,12 +5,32 @@
 // See: https://github.com/giphy/GiphyAPI#access-and-api-keys
 define('GIPHY_API_KEY', 'dc6zaTOxFJmzC');
 
-// Get request
-$trigger = $_POST['trigger_word'];
-$text = $_POST['text'];
+// maximum number to retrieve,
+// can be overridden by gifbomb count
+$limit = 25;
+$count = 0;
 
-// build search string
-$search  = trim(substr($text, strlen($trigger) + 1));
+// Get request
+$trigger = $_GET['trigger_word']; // gif or gifbomb
+$text = $_GET['text'];
+
+// single use, or return multiples?
+if ($trigger == 'gif') {
+    $regex = '/^' . $trigger . ' (.+)$/';
+    $results = preg_match($regex, $text, $matches);
+    $search = $matches[1];
+} else if ($trigger == 'gifbomb') {
+    $regex = '/^' . $trigger . ' (\d+) (.+)$/';
+    $results = preg_match($regex, $text, $matches);
+    $count = $matches[1];
+    $search = $matches[2];
+}
+
+
+echo $search . '<br /><br />';
+echo $count . '<br /><br />';
+// print_r($matches);
+
 
 // fail if search string is empty
 if ($search == '') {
@@ -19,7 +39,6 @@ if ($search == '') {
 }
 
 // Query Giphy - http://giphy.com/
-$limit    = 25;
 $response = file_get_contents('http://api.giphy.com/v1/gifs/search?q=' .
             urlencode($search) . '&api_key=' . GIPHY_API_KEY . '&limit=' . $limit . '&offset=0');
 $response = json_decode($response);
@@ -41,3 +60,5 @@ header('Content-Type: application/json');
 echo json_encode(array(
     'text' => $response
 ));
+
+?>

--- a/GifBot.php
+++ b/GifBot.php
@@ -46,8 +46,8 @@ $response_data = array();
 if ($count) {
     // get random `$num` keys from response
     $keys = array_rand($gifs, $num);
-    // array_rand returns the index if `$num` is an array
-    // else it returns an array if `$num` is greater than 1
+    // array_rand returns the rancom index if `$num` is 1
+    // else it returns an array of indexes if `$num` is greater than 1
     if (is_array($keys)) {
         // loop over the random keys, append image data to `$response_data`
         for ($i=1; $i<=count($keys); $i++) {

--- a/GifBot.php
+++ b/GifBot.php
@@ -12,8 +12,8 @@ $limit = 25;
 $num = 1;
 
 // Get request
-$trigger = $_GET['trigger_word']; // currently gif or gifbomb
-$text = $_GET['text'];
+$trigger = $_POST['trigger_word']; // currently gif or gifbomb
+$text = $_POST['text'];
 
 // multiple images, or just a one-off?
 if ($trigger == 'gifbomb') {
@@ -50,7 +50,7 @@ if ($count) {
     // else it returns an array if `$num` is greater than 1
     if (is_array($keys)) {
         // loop over the random keys, append image data to `$response_data`
-        for ($i=0; $i<=count($keys); $i++) {
+        for ($i=1; $i<=count($keys); $i++) {
             $response_data[] = $gifs[$i]->images->original->url;
         }
     } else {

--- a/GifBot.php
+++ b/GifBot.php
@@ -7,24 +7,24 @@ define('GIPHY_API_KEY', 'dc6zaTOxFJmzC');
 
 // maximum number to retrieve
 $limit = 25;
-// the number of images to return
-// can be overridden by gifbomb count
-$num = 1;
+
+// images to return when gifbombing
+$gifbomb_total = 5;
 
 // Get request
 $trigger = $_POST['trigger_word']; // currently gif or gifbomb
 $text = $_POST['text'];
 
+// extract search string
+$regex = '/^' . $trigger . ' (.+)$/';
+$results = preg_match($regex, $text, $matches);
+$search = $matches[1];
+
 // multiple images, or just a one-off?
 if ($trigger == 'gifbomb') {
-    $regex = '/^' . $trigger . ' (\d+) (.+)$/';
-    $results = preg_match($regex, $text, $matches);
-    $num = $matches[1];
-    $search = $matches[2];
+    $num = $gifbomb_total;
 } else {
-    $regex = '/^' . $trigger . ' (.+)$/';
-    $results = preg_match($regex, $text, $matches);
-    $search = $matches[1];
+    $num = 1;
 }
 
 // fail if search string is empty

--- a/GifBot_test.html
+++ b/GifBot_test.html
@@ -4,6 +4,7 @@
     <style>
         * { font-family: "Trebuchet MS", verdana, arial, sans-serif; }
         input { font-size: 1.2em; }
+        input[type=text] { width: 300px; }
         #results {
             border: 2px dashed #bbbbbb;
             color: #bbbbbb;
@@ -25,9 +26,17 @@
         You might want to delete this page when you're done.
     </p>
 
-    <form action="GifBot.php" method="POST">
+    <form action="GifBot.php" method="get">
+        <h3>Single Result</h3>
         <input type="hidden" name="trigger_word" value="gif" />
         Search phrase: <input type="text" name="text" placeholder="gif <search term>" />
+        <input type="submit" />
+    </form>
+
+    <form action="GifBot.php" method="get">
+        <h3>Multiple Results</h3>
+        <input type="hidden" name="trigger_word" value="gifbomb" />
+        Search phrase: <input type="text" name="text" placeholder="gifbomb <number> <search term>" />
         <input type="submit" />
     </form>
 
@@ -46,7 +55,7 @@
                     trigger_word = $form.find('[name="trigger_word"]').val(),
                     url = $(this).attr('action');
 
-                $.post(url, { text: text, trigger_word: trigger_word })
+                $.get(url, { text: text, trigger_word: trigger_word })
                     .success(function(data){
                         var $resultContainer = $('#results'),
                             result;

--- a/GifBot_test.html
+++ b/GifBot_test.html
@@ -34,9 +34,10 @@
     </form>
 
     <form action="GifBot.php" method="post">
-        <h3>Multiple Results</h3>
+        <h3>Multiple Results (defaults to 5)</h3>
+        <p>Can be changed in GifBot.php.</p>
         <input type="hidden" name="trigger_word" value="gifbomb" />
-        Search phrase: <input type="text" name="text" placeholder="gifbomb <number> <search term>" />
+        Search phrase: <input type="text" name="text" placeholder="gifbomb <search term>" />
         <input type="submit" />
     </form>
 

--- a/GifBot_test.html
+++ b/GifBot_test.html
@@ -26,14 +26,14 @@
         You might want to delete this page when you're done.
     </p>
 
-    <form action="GifBot.php" method="get">
+    <form action="GifBot.php" method="post">
         <h3>Single Result</h3>
         <input type="hidden" name="trigger_word" value="gif" />
         Search phrase: <input type="text" name="text" placeholder="gif <search term>" />
         <input type="submit" />
     </form>
 
-    <form action="GifBot.php" method="get">
+    <form action="GifBot.php" method="post">
         <h3>Multiple Results</h3>
         <input type="hidden" name="trigger_word" value="gifbomb" />
         Search phrase: <input type="text" name="text" placeholder="gifbomb <number> <search term>" />
@@ -55,12 +55,16 @@
                     trigger_word = $form.find('[name="trigger_word"]').val(),
                     url = $(this).attr('action');
 
-                $.get(url, { text: text, trigger_word: trigger_word })
+                $.post(url, { text: text, trigger_word: trigger_word })
                     .success(function(data){
                         var $resultContainer = $('#results'),
+                            arr,
                             result;
                         if (data.text.indexOf('http') >= 0) {
-                            result = '<img src="' + data.text + '" />';
+                            arr = data.text.split(' ');
+                            arr.forEach(function(img){
+                                result += '<img src="' + img + '" />';
+                            })
                         } else {
                             result = data.text;
                         }


### PR DESCRIPTION
Add support for gifbomb. Usage as follows:
- `#gif {search_term}
- `#gifbomb {num} {search_term}

Demo file displays either option, allowing users to double check functionality.
